### PR TITLE
Fix for deadlock on errsig

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -65,7 +65,7 @@ func (p *Proxy) Start() {
 		p.rconn, err = net.DialTCP("tcp", nil, p.raddr)
 	}
 	if err != nil {
-		p.err("Remote connection failed: %s", err)
+		p.Log.Warn("Remote connection failed: %s", err)
 		return
 	}
 	defer p.rconn.Close()


### PR DESCRIPTION
Remote connection error report (p.err("Remote connection failed: %s", err)) blocks on errsig channel that is not actively read at this time.
As a side effect proxy keeps open sockets for incoming connections and leaks resources not terminating goroutine handling client session.