### PR TITLE
Add a simple retry to re-resolve the DNS host if the IP address has changed [ Feedback Required ]

### DIFF
--- a/cmd/tcp-proxy/main.go
+++ b/cmd/tcp-proxy/main.go
@@ -75,7 +75,7 @@ func main() {
 			logger.Info("Unwrapping TLS")
 			p = proxy.NewTLSUnwrapped(conn, laddr, raddr, *remoteAddr)
 		} else {
-			p = proxy.New(conn, laddr, raddr)
+			p = proxy.New(conn, laddr, raddr, *remoteAddr)
 		}
 
 		p.Matcher = matcher


### PR DESCRIPTION
Here is the testing output.

After the target IP address changes and the DNS record is updated, we retry the `net.ResolveTCPAddr`:
```
Connection #001 Closed (10109150 bytes sent, 9 bytes recieved)
Connection #002 Remote connection failed: dial tcp 172.18.0.31:6379: connect: no route to host, retry DNS resolution
Connection #002 Opened 0.0.0.0:6379 >>> 172.18.0.33:6379
Connection #002 >>> 20 bytes sent
...
```

After the remote host is stopped, we just return the failure but the go routine keeps running the same as previous failure:
```
Connection #002 Closed (10109150 bytes sent, 9 bytes recieved)
Connection #003 Remote connection failed: dial tcp 172.18.0.31:6379: connect: no route to host, retry DNS resolution
Connection #003 Remote connection failed: lookup redis-primary on 127.0.0.11:53: no such host
```

After the host returns again on the same IP:
```
Connection #002 Closed (10109150 bytes sent, 9 bytes recieved)
Connection #003 Remote connection failed: dial tcp 172.18.0.31:6379: connect: no route to host, retry DNS resolution
Connection #003 Remote connection failed: lookup redis-primary on 127.0.0.11:53: no such host
Connection #004 Remote connection failed: dial tcp 172.18.0.31:6379: connect: no route to host, retry DNS resolution
Connection #004 Opened 0.0.0.0:6379 >>> 172.18.0.33:6379
Connection #004 >>> 20 bytes sent
...
```

## Problems with this PR

I believe because the Start function references a pointer to the proxy struct, when we set the new IP address after resolving the new name, any future session will be still using the old IP first. Any ideas on circumventing this would be appreciated.