### PR TITLE
Port Mirroring

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Usage of tcp-proxy:
   -l="localhost:9999": local address
   -n: disable nagles algorithm
   -r="localhost:80": remote address
+  -m="localhost:9001": mirror request address e.g. localhost:9001
+  -o="localhost:9002": mirror response address e.g. localhost:9002
   -match="": match regex (in the form 'regex')
   -replace="": replace regex (in the form 'regex~replacer')
   -v: display server actions

--- a/cmd/tcp-proxy/main.go
+++ b/cmd/tcp-proxy/main.go
@@ -37,7 +37,7 @@ func main() {
 		Color:   *colors,
 	}
 
-	logger.Info("go-tcp-proxy (%s) proxing from %v to %v ", version, *localAddr, *remoteAddr)
+	logger.Info("go-tcp-proxy (%s) proxying from %s to %s", version, *localAddr, *remoteAddr)
 
 	laddr, err := net.ResolveTCPAddr("tcp", *localAddr)
 	if err != nil {

--- a/cmd/tcp-proxy/main.go
+++ b/cmd/tcp-proxy/main.go
@@ -17,16 +17,18 @@ var (
 	connid  = uint64(0)
 	logger  proxy.ColorLogger
 
-	localAddr   = flag.String("l", ":9999", "local address")
-	remoteAddr  = flag.String("r", "localhost:80", "remote address")
-	verbose     = flag.Bool("v", false, "display server actions")
-	veryverbose = flag.Bool("vv", false, "display server actions and all tcp data")
-	nagles      = flag.Bool("n", false, "disable nagles algorithm")
-	hex         = flag.Bool("h", false, "output hex")
-	colors      = flag.Bool("c", false, "output ansi colors")
-	unwrapTLS   = flag.Bool("unwrap-tls", false, "remote connection with TLS exposed unencrypted locally")
-	match       = flag.String("match", "", "match regex (in the form 'regex')")
-	replace     = flag.String("replace", "", "replace regex (in the form 'regex~replacer')")
+	localAddr      = flag.String("l", ":9999", "local address")
+	remoteAddr     = flag.String("r", "localhost:80", "remote address")
+	mirrorReqAddr  = flag.String("m", "", "mirror request address e.g. localhost:9001")
+	mirrorRespAddr = flag.String("o", "", "mirror response address e.g. localhost:9002")
+	verbose        = flag.Bool("v", false, "display server actions")
+	veryverbose    = flag.Bool("vv", false, "display server actions and all tcp data")
+	nagles         = flag.Bool("n", false, "disable nagles algorithm")
+	hex            = flag.Bool("h", false, "output hex")
+	colors         = flag.Bool("c", false, "output ansi colors")
+	unwrapTLS      = flag.Bool("unwrap-tls", false, "remote connection with TLS exposed unencrypted locally")
+	match          = flag.String("match", "", "match regex (in the form 'regex')")
+	replace        = flag.String("replace", "", "replace regex (in the form 'regex~replacer')")
 )
 
 func main() {
@@ -48,6 +50,24 @@ func main() {
 	if err != nil {
 		logger.Warn("Failed to resolve remote address: %s", err)
 		os.Exit(1)
+	}
+	var mReqAddr *net.TCPAddr
+	if *mirrorReqAddr != "" {
+		mReqAddr, err = net.ResolveTCPAddr("tcp", *mirrorReqAddr)
+		if err != nil {
+			logger.Warn("Failed to resolve mirror requests address: %s", err)
+			os.Exit(1)
+		}
+		logger.Info("proxying incoming requests from %s to %s", *localAddr, *mirrorReqAddr)
+	}
+	var mRespAddr *net.TCPAddr
+	if *mirrorRespAddr != "" {
+		mRespAddr, err = net.ResolveTCPAddr("tcp", *mirrorRespAddr)
+		if err != nil {
+			logger.Warn("Failed to resolve mirror responses address: %s", err)
+			os.Exit(1)
+		}
+		logger.Info("proxying outgoing responses from %s to %s", *localAddr, *mirrorRespAddr)
 	}
 	listener, err := net.ListenTCP("tcp", laddr)
 	if err != nil {
@@ -73,9 +93,9 @@ func main() {
 		var p *proxy.Proxy
 		if *unwrapTLS {
 			logger.Info("Unwrapping TLS")
-			p = proxy.NewTLSUnwrapped(conn, laddr, raddr, *remoteAddr)
+			p = proxy.NewTLSUnwrapped(conn, laddr, raddr, mReqAddr, mRespAddr, *remoteAddr)
 		} else {
-			p = proxy.New(conn, laddr, raddr)
+			p = proxy.New(conn, laddr, raddr, mReqAddr, mRespAddr)
 		}
 
 		p.Matcher = matcher

--- a/proxy.go
+++ b/proxy.go
@@ -89,7 +89,7 @@ func (p *Proxy) Start() {
 
 	//wait for close...
 	<-p.errsig
-	p.Log.Info("Closed (%d bytes sent, %d bytes recieved)", p.sentBytes, p.receivedBytes)
+	p.Log.Info("Closed (%d bytes sent, %d bytes received)", p.sentBytes, p.receivedBytes)
 }
 
 func (p *Proxy) err(s string, err error) {
@@ -108,9 +108,9 @@ func (p *Proxy) pipe(src, dst io.ReadWriter) {
 
 	var dataDirection string
 	if islocal {
-		dataDirection = ">>> %d bytes sent%s"
+		dataDirection = ">>> %d bytes sent %s"
 	} else {
-		dataDirection = "<<< %d bytes recieved%s"
+		dataDirection = "<<< %d bytes received %s"
 	}
 
 	var byteFormat string

--- a/proxy.go
+++ b/proxy.go
@@ -12,6 +12,10 @@ type Proxy struct {
 	receivedBytes uint64
 	laddr, raddr  *net.TCPAddr
 	lconn, rconn  io.ReadWriteCloser
+	mReqAddr      *net.TCPAddr
+	mRespAddr     *net.TCPAddr
+	mReqConn      io.ReadWriteCloser
+	mRespConn     io.ReadWriteCloser
 	erred         bool
 	errsig        chan bool
 	tlsUnwrapp    bool
@@ -28,22 +32,24 @@ type Proxy struct {
 
 // New - Create a new Proxy instance. Takes over local connection passed in,
 // and closes it when finished.
-func New(lconn *net.TCPConn, laddr, raddr *net.TCPAddr) *Proxy {
+func New(lconn *net.TCPConn, laddr, raddr, mReqAddr, mRespAddr *net.TCPAddr) *Proxy {
 	return &Proxy{
-		lconn:  lconn,
-		laddr:  laddr,
-		raddr:  raddr,
-		erred:  false,
-		errsig: make(chan bool),
-		Log:    NullLogger{},
+		lconn:     lconn,
+		laddr:     laddr,
+		raddr:     raddr,
+		mReqAddr:  mReqAddr,
+		mRespAddr: mRespAddr,
+		erred:     false,
+		errsig:    make(chan bool),
+		Log:       NullLogger{},
 	}
 }
 
 // NewTLSUnwrapped - Create a new Proxy instance with a remote TLS server for
 // which we want to unwrap the TLS to be able to connect without encryption
 // locally
-func NewTLSUnwrapped(lconn *net.TCPConn, laddr, raddr *net.TCPAddr, addr string) *Proxy {
-	p := New(lconn, laddr, raddr)
+func NewTLSUnwrapped(lconn *net.TCPConn, laddr, raddr, mReqAddr, mRespAddr *net.TCPAddr, addr string) *Proxy {
+	p := New(lconn, laddr, raddr, mReqAddr, mRespAddr)
 	p.tlsUnwrapp = true
 	p.tlsAddress = addr
 	return p
@@ -70,6 +76,23 @@ func (p *Proxy) Start() {
 	}
 	defer p.rconn.Close()
 
+	if p.mReqAddr != nil {
+		p.mReqConn, err = net.DialTCP("tcp", nil, p.mReqAddr)
+		if err != nil {
+			p.Log.Warn("Mirror requests connection failed: %s", err)
+			return
+		}
+		defer p.mReqConn.Close()
+	}
+	if p.mRespAddr != nil {
+		p.mRespConn, err = net.DialTCP("tcp", nil, p.mRespAddr)
+		if err != nil {
+			p.Log.Warn("Mirror responses connection failed: %s", err)
+			return
+		}
+		defer p.mRespConn.Close()
+	}
+
 	//nagles?
 	if p.Nagles {
 		if conn, ok := p.lconn.(setNoDelayer); ok {
@@ -78,14 +101,24 @@ func (p *Proxy) Start() {
 		if conn, ok := p.rconn.(setNoDelayer); ok {
 			conn.SetNoDelay(true)
 		}
+		if p.mReqConn != nil {
+			if conn, ok := p.mReqConn.(setNoDelayer); ok {
+				conn.SetNoDelay(true)
+			}
+		}
+		if p.mRespConn != nil {
+			if conn, ok := p.mRespConn.(setNoDelayer); ok {
+				conn.SetNoDelay(true)
+			}
+		}
 	}
 
 	//display both ends
 	p.Log.Info("Opened %s >>> %s", p.laddr.String(), p.raddr.String())
 
 	//bidirectional copy
-	go p.pipe(p.lconn, p.rconn)
-	go p.pipe(p.rconn, p.lconn)
+	go p.pipe(p.lconn, p.rconn, p.mReqConn)
+	go p.pipe(p.rconn, p.lconn, p.mRespConn)
 
 	//wait for close...
 	<-p.errsig
@@ -103,7 +136,7 @@ func (p *Proxy) err(s string, err error) {
 	p.erred = true
 }
 
-func (p *Proxy) pipe(src, dst io.ReadWriter) {
+func (p *Proxy) pipe(src, dst, mirror io.ReadWriter) {
 	islocal := src == p.lconn
 
 	var dataDirection string
@@ -149,6 +182,12 @@ func (p *Proxy) pipe(src, dst io.ReadWriter) {
 		if err != nil {
 			p.err("Write failed '%s'\n", err)
 			return
+		}
+		if mirror != nil {
+			_, err = mirror.Write(b)
+			if err != nil {
+				p.Log.Warn("Write to mirror failed '%s'\n", err)
+			}
 		}
 		if islocal {
 			p.sentBytes += uint64(n)


### PR DESCRIPTION
I need a proxy to imitate a port mirroring (SPAN) that will be used for a logging.
There is some NGINX module http://nginx.org/en/docs/http/ngx_http_mirror_module.html but it mirrors only requests. For my case I need responses from the remote too.
Here I patched your proxy and hope this may be useful to add as a fature